### PR TITLE
Specify job namespace instead of target namespace after https://githu…

### DIFF
--- a/cli/cmd/kubernetes/launch.go
+++ b/cli/cmd/kubernetes/launch.go
@@ -50,7 +50,7 @@ func DeleteProfilingJob(job *batchv1.Job, targetDetails *data.TargetDetails, ctx
 	deleteStrategy := metav1.DeletePropagationForeground
 	return clientSet.
 		BatchV1().
-		Jobs(targetDetails.Namespace).
+		Jobs(job.Namespace).
 		Delete(ctx, job.Name, metav1.DeleteOptions{
 			PropagationPolicy: &deleteStrategy,
 		})


### PR DESCRIPTION
…b.com/yahoo/kubectl-flame/pull/64

Otherwise it silently fails, attempting deleting the job from the target namespace.